### PR TITLE
HIKE-3489 | Ensure frame is not null before checking parentFrame

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor
 .phpunit.result.cache
 .php-cs-fixer.cache
 .phpunit.cache
+.idea/

--- a/bin/browser.cjs
+++ b/bin/browser.cjs
@@ -139,7 +139,12 @@ const callChrome = async pup => {
         });
 
         page.on('response', function (response) {
-            if (response.request().isNavigationRequest() && response.request().frame().parentFrame() === null) {
+            const frame = response.request().frame();
+            if (
+              response.request().isNavigationRequest()
+              && frame
+              && frame.parentFrame() === null
+            ) {
                 redirectHistory.push({
                     url: response.request().url(),
                     status: response.status(),


### PR DESCRIPTION
This PR adds a check that `frame()` exists before checking `parentFrame()`.
Currently the code is `response.request().frame().parentFrame()` which will throw a TypeError: Cannot read properties of null (reading 'parentFrame') when `frame()` is null.

Issue raised here: https://github.com/spatie/browsershot/discussions/895
Puppeteer docs confirming frame() can be null: https://pptr.dev/api/puppeteer.httprequest.frame